### PR TITLE
Refactor agents variable declaration for clarity

### DIFF
--- a/InvestigationGame/Program.cs
+++ b/InvestigationGame/Program.cs
@@ -40,7 +40,7 @@ namespace InvestigationGame
                 Enums.SensorType.Light
             };
 
-            var agents = new List<IAgent>();
+            List<IAgent> agents = new List<IAgent>();
             var random = new Random();
             for (int i = 0; i < count; i++)
             {


### PR DESCRIPTION
Changed the declaration of the `agents` variable from using `var` to explicitly specifying the type
`List<IAgent>`. This improves code readability and clarity regarding the variable's type.