### PR TITLE
Refactor counterattack logic and enhance agent interfaces

### DIFF
--- a/InvestigationGame/Agents/OrganizationLeaderAgent.cs
+++ b/InvestigationGame/Agents/OrganizationLeaderAgent.cs
@@ -46,20 +46,26 @@ namespace InvestigationGame.Agents
             return $"{Name} - Weaknesses: {string.Join(", ", SecretWeaknesses)}";
         }
 
-        public void CounterAttack(List<ISensor> attachedSensors)
+        public List<ISensor> CounterAttack(List<ISensor> attachedSensors)
         {
             CounterAttackTurn++;
             if (CounterAttackTurn % 3 == 0 && attachedSensors.Count > 0)
             {
-                attachedSensors.Clear();
-                Console.WriteLine("Counterattack! All sensors were removed by the Organization Leader.");
+                var rand = new Random();
+                int idx = rand.Next(attachedSensors.Count);
+                string removedSensorName = attachedSensors[idx].Name;
+                attachedSensors.RemoveAt(idx);
+                Console.WriteLine($"Counterattack! The Sensor {removedSensorName} was removed by the Squad Leader.");
+                return attachedSensors;
             }
             if (CounterAttackTurn % 10 == 0)
             {
                 SecretWeaknesses = new List<string>(_originalWeaknesses);
                 attachedSensors.Clear();
                 Console.WriteLine("Major counterattack! Weaknesses reset and all sensors removed.");
+                return attachedSensors;
             }
+            return attachedSensors;
         }
     }
 }

--- a/InvestigationGame/Agents/SeniorCommanderAgent.cs
+++ b/InvestigationGame/Agents/SeniorCommanderAgent.cs
@@ -46,26 +46,31 @@ namespace InvestigationGame.Agents
             return $"{Name} - Weaknesses: {string.Join(", ", SecretWeaknesses)}";
         }
 
-        public void CounterAttack(List<ISensor> attachedSensors)
+        public List<ISensor> CounterAttack(List<ISensor> attachedSensors)
         {
             CounterAttackTurn++;
             if (CounterAttackTurn % 3 == 0 && attachedSensors.Count > 0)
             {
                 var rand = new Random();
                 int removeCount = Math.Min(2, attachedSensors.Count);
+                List<string> removedSensors = new List<string>();
                 for (int i = 0; i < removeCount; i++)
                 {
                     int idx = rand.Next(attachedSensors.Count);
                     attachedSensors.RemoveAt(idx);
+                    removedSensors.Add(attachedSensors[idx].Name);
                 }
-                Console.WriteLine("Counterattack! Two sensors were removed by the Senior Commander.");
+                Console.WriteLine($"Counterattack! Two sensors, {removedSensors.ToString()} were removed by the Senior Commander.");
+                return attachedSensors;
             }
             if (CounterAttackTurn % 10 == 0)
             {
                 SecretWeaknesses = new List<string>(_originalWeaknesses);
                 attachedSensors.Clear();
                 Console.WriteLine("Major counterattack! Weaknesses reset and all sensors removed.");
+                return attachedSensors;
             }
+            return attachedSensors;
         }
     }
 }

--- a/InvestigationGame/Agents/SquadLeaderAgent.cs
+++ b/InvestigationGame/Agents/SquadLeaderAgent.cs
@@ -36,7 +36,7 @@ namespace InvestigationGame.Agents
 
         public bool IsExposed(List<ISensor> sensors)
         {
-            return EvaluateSensors(sensors) == SecretWeaknesses.Count;
+            return EvaluateSensors(sensors) == SensorSlots;
         }
 
         // add the toString method to provide a string representation of the agent
@@ -45,16 +45,18 @@ namespace InvestigationGame.Agents
             return $"{Name} - Weaknesses: {string.Join(", ", SecretWeaknesses)}";
         }
 
-        public void CounterAttack(List<ISensor> attachedSensors)
+        public List<ISensor> CounterAttack(List<ISensor> attachedSensors)
         {
             CounterAttackTurn++;
             if (CounterAttackTurn % 3 == 0 && attachedSensors.Count > 0)
             {
                 var rand = new Random();
                 int idx = rand.Next(attachedSensors.Count);
+                string removedSensorName = attachedSensors[idx].Name;
                 attachedSensors.RemoveAt(idx);
-                Console.WriteLine("Counterattack! A sensor was removed by the Squad Leader.");
+                Console.WriteLine($"Counterattack! The Sensor {removedSensorName} was removed by the Squad Leader.");
             }
+            return attachedSensors;
         }
     }
 }

--- a/InvestigationGame/Interface/IAgent.cs
+++ b/InvestigationGame/Interface/IAgent.cs
@@ -6,7 +6,7 @@ namespace InvestigationGame.Interface
     {
         string Name { get; set; }
         List<string> SecretWeaknesses { get; set; }
-        int SensorSlots { get; set; }
+        int SensorSlots { get; set; } 
         int EvaluateSensors(List<ISensor> sensors);
         bool IsExposed(List<ISensor> sensors);
         string ToString();

--- a/InvestigationGame/Interface/ICounterAttackAgent.cs
+++ b/InvestigationGame/Interface/ICounterAttackAgent.cs
@@ -4,6 +4,6 @@ namespace InvestigationGame.Interface
 {
     public interface ICounterAttackAgent
     {
-        void CounterAttack(List<ISensor> attachedSensors);
+        List<ISensor> CounterAttack(List<ISensor> attachedSensors);
     }
 }


### PR DESCRIPTION
- Updated `CounterAttack` methods in agent classes to return a list of `ISensor` objects.
- Enhanced sensor removal logic in `SeniorCommanderAgent` to remove up to two sensors and display their names.
- Modified `IsExposed` method in `SquadLeaderAgent` to compare against `SensorSlots`.
- Added `SensorSlots` property to the `IAgent` interface.
- Changed `ICounterAttackAgent` interface to reflect the new return type for `CounterAttack`.
- Updated `InvestigationManager` constructor to throw an exception for null agents and streamlined counterattack handling.
- Introduced `ActivateRevel` method in `InvestigationManager` for special sensor reveal abilities.
- Added `GetAttachedSensors` method to expose attached sensors for external checks.